### PR TITLE
Fix broken switches without libadwaita

### DIFF
--- a/src/romm_sync_app.py
+++ b/src/romm_sync_app.py
@@ -211,6 +211,13 @@ except ValueError:
             def set_active(self, active):
                 self.switch.set_active(active)
 
+            def connect(self, signal_name, callback):
+                if signal_name in ('notify::active'):
+                    # Forward to the internal switch widget's signal
+                    return self.switch.connect(signal_name, callback)
+                else:
+                    return super().connect(signal_name, callback)
+
         class EntryRow(Gtk.Box):
             def __init__(self):
                 super().__init__(orientation=Gtk.Orientation.VERTICAL)


### PR DESCRIPTION
The signal for the switch being flipped wasn't correctly connected on `MockAdw.SwitchRow`, so these switches were nonfunctional in such environments.