### PR TITLE
Implement "portable" launch vars

### DIFF
--- a/src/romm_sync_app.py
+++ b/src/romm_sync_app.py
@@ -8912,7 +8912,7 @@ class SyncWindow(Gtk.ApplicationWindow):
         # Write to file only if debug mode is enabled
         if debug_mode:
             try:
-                log_file = Path.home() / '.config' / 'romm-retroarch-sync' / 'debug.log'
+                log_file = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync' / 'debug.log'))
                 log_file.parent.mkdir(parents=True, exist_ok=True)
                 with open(log_file, 'a', encoding='utf-8') as f:
                     import datetime

--- a/src/romm_sync_app.py
+++ b/src/romm_sync_app.py
@@ -8912,7 +8912,7 @@ class SyncWindow(Gtk.ApplicationWindow):
         # Write to file only if debug mode is enabled
         if debug_mode:
             try:
-                log_file = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync' / 'debug.log'))
+                log_file = Path.home() / '.config' / 'romm-retroarch-sync' / 'debug.log'
                 log_file.parent.mkdir(parents=True, exist_ok=True)
                 with open(log_file, 'a', encoding='utf-8') as f:
                     import datetime

--- a/src/sync_core.py
+++ b/src/sync_core.py
@@ -3551,13 +3551,12 @@ class RetroArchInterface:
         self._is_retrodeck_cache = None
 
         # Check for custom path override first
-        custom_path = self.settings.get('RetroArch', 'custom_path', '').strip()
+        custom_path = os.environ.get('RETROARCH_DIR') or self.settings.get('RetroArch', 'custom_path', '').strip()
 
         if custom_path and Path(custom_path).exists():
             self.retroarch_executable = custom_path
             print(f"🎮 Using custom RetroArch path: {custom_path}")
             
-            # ALSO CHECK FOR CORES RELATIVE TO CUSTOM PATH
             custom_cores_dir = Path(custom_path) / 'cores'
             if custom_cores_dir.exists():
                 self.cores_dir = custom_cores_dir

--- a/src/sync_core.py
+++ b/src/sync_core.py
@@ -3992,8 +3992,10 @@ class RetroArchInterface:
         
         try:
             import subprocess
-            
             # Build command based on RetroArch type - REPLACE THIS SECTION
+
+            self.retroarch_executable = os.environ.get('RETROARCH_EXECUTABLE') or self.retroarch_executable
+
             if 'retrodeck' in self.retroarch_executable.lower():
                 # RetroDECK launches games differently - try multiple approaches
                 cmd = ['flatpak', 'run', 'net.retrodeck.retrodeck', '--pass-args', str(rom_path)]
@@ -4003,7 +4005,7 @@ class RetroArchInterface:
                 cmd = ['snap', 'run', 'retroarch', '-L', core_path, str(rom_path)]
             else:
                 cmd = [self.retroarch_executable, '-L', core_path, str(rom_path)]
-            
+
             logging.debug(f"Launching: {' '.join(cmd)}")
             logging.debug(f"ROM path exists: {os.path.exists(rom_path)}, Core path exists: {os.path.exists(core_path)}")
 

--- a/src/sync_core.py
+++ b/src/sync_core.py
@@ -83,7 +83,7 @@ class GameDataCache:
     
     def __init__(self, settings_manager):
         self.settings = settings_manager
-        self.cache_dir = Path.home() / '.config' / 'romm-retroarch-sync' / 'cache'
+        _base = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync'))
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         
         # Cache files
@@ -703,7 +703,7 @@ class SettingsManager:
     """Handle saving and loading application settings"""
     
     def __init__(self):
-        self.config_dir = Path.home() / '.config' / 'romm-retroarch-sync'
+        _base = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync'))
         self.config_file = self.config_dir / 'settings.ini'
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
@@ -763,8 +763,8 @@ class SettingsManager:
                 'auto_refresh': 'false'
             }
             self.config['Download'] = {
-                'rom_directory': str(Path.home() / 'RomMSync' / 'roms'),
-                'save_directory': str(Path.home() / 'RomMSync' / 'saves'),
+                'rom_directory': str(Path(os.environ.get('ROMM_SYNC_DIR', Path.home() / 'RomMSync' / 'roms'))),
+                'saves_directory': str(Path(os.environ.get('RETROARCH_SAVES_DIR', Path.home() / 'RomMSync' / 'saves'))),
             }
             self.config['BIOS'] = {
                 'verify_on_launch': 'false',
@@ -6553,7 +6553,7 @@ class AutoSyncLock:
     """Linux-only file locking to prevent multiple auto-sync instances"""
     
     def __init__(self):
-        self.lock_file = Path.home() / '.config' / 'romm-retroarch-sync' / 'autosync.lock'
+        self.lock_file = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync'))
         self.lock_file.parent.mkdir(parents=True, exist_ok=True)
         self.lock_fd = None
     

--- a/src/sync_core.py
+++ b/src/sync_core.py
@@ -83,7 +83,7 @@ class GameDataCache:
     
     def __init__(self, settings_manager):
         self.settings = settings_manager
-        _base = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync'))
+        self.cache_dir = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync'))
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         
         # Cache files
@@ -703,7 +703,7 @@ class SettingsManager:
     """Handle saving and loading application settings"""
     
     def __init__(self):
-        _base = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync'))
+        self.config_dir = Path(os.environ.get('ROMM_CONFIG_DIR', Path.home() / '.config' / 'romm-retroarch-sync'))
         self.config_file = self.config_dir / 'settings.ini'
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
@@ -4123,6 +4123,9 @@ class RetroArchInterface:
         # All possible RetroArch config locations (ordered by likelihood)
         possible_dirs = [
 
+            # Custom defined install
+            Path(os.environ['RETROARCH_DIR']) if os.environ.get('RETROARCH_DIR') else None,
+
             # RetroDECK
             Path.home() / 'retrodeck',
 
@@ -4188,6 +4191,8 @@ class RetroArchInterface:
 
         # Standard detection logic
         possible_dirs = [
+            # Custom defined install
+            Path(os.environ['RETROARCH_DIR']) if os.environ.get('RETROARCH_DIR') else None,
             # RetroDECK (correct path)
             Path.home() / '.var/app/net.retrodeck.retrodeck/config/retroarch',
             # Flatpak RetroArch (prioritize over generic retrodeck folder)

--- a/src/sync_core.py
+++ b/src/sync_core.py
@@ -3558,10 +3558,7 @@ class RetroArchInterface:
             print(f"🎮 Using custom RetroArch path: {custom_path}")
             
             # ALSO CHECK FOR CORES RELATIVE TO CUSTOM PATH
-            custom_config_dir = Path(custom_path).parent
-            if (custom_config_dir / 'config/retroarch').exists():
-                custom_config_dir = custom_config_dir / 'config/retroarch'
-            custom_cores_dir = custom_config_dir / 'cores'
+            custom_cores_dir = Path(custom_path) / 'cores'
             if custom_cores_dir.exists():
                 self.cores_dir = custom_cores_dir
                 print(f"🔧 Using custom cores directory: {custom_cores_dir}")


### PR DESCRIPTION
This is a ~~very bad and rudimentary~~ attempt to make this application "portable" 

I have a portable version of Retroarch and romm-retroarch-sync in a folder that can be deployed to any PC and this launch script to get the dirs set correctly:

#!/bin/bash
DIR="$(cd "$(dirname "$0")" && pwd)"
export ROMM_SYNC_DIR="$DIR/RomM Sync"
export ROMM_CONFIG_DIR="$DIR/bin/romm-sync"
export RETROARCH_SAVES_DIR="$DIR/saves"
export RETROARCH_CONFIG_DIR="$DIR/config"
exec "$DIR/bin/RomM-RetroArch-Sync-patched.AppImage"

Unfortunately I have no idea if the changes I've added have broken the default dir location detection, and regardless have not been able to get romm-sync-retroarch to be able to detect the install location of retroarch to be $DIR and sync saves properly.

I do not know any python, but I'm willing to try to learn how to help contribute to this project as everyone has to start somewhere.